### PR TITLE
Add state normalization helpers and unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,15 @@ This will:
 - Run all validation tests
 - Generate a HTML report
 
+### Running Unit Tests
+
+The helper functions used for state normalisation are covered by unit tests.
+Run them with:
+
+```bash
+pytest
+```
+
 ## Test Details
 
 ### OSPF Validator

--- a/bgp_peer_check/bgp_peer_check.py
+++ b/bgp_peer_check/bgp_peer_check.py
@@ -25,6 +25,11 @@ EXPECTED_BGP_PEERS = {
 logging.basicConfig(level=logging.ERROR)
 logger = logging.getLogger(__name__)
 
+
+def normalize_bgp_state(state: str) -> str:
+    """Return a normalised BGP neighbor state string."""
+    return state.lower().strip() if state else ""
+
 class CommonSetup(aetest.CommonSetup):
 
     @aetest.subsection
@@ -98,10 +103,7 @@ class BGPPeerValidator(aetest.Testcase):
                             for nei_id, nei_data in vrf_data.get('neighbor', {}).items():
                                 if nei_id == peer_id:
                                     peer_found = True
-                                    """
-                                    Get state & normalise - some variations in output format between OS
-                                    """
-                                    state = nei_data.get('session_state', '').lower()
+                                    state = normalize_bgp_state(nei_data.get('session_state', ''))
                                     if state:
                                         actual_state = state
                                     else:
@@ -115,10 +117,7 @@ class BGPPeerValidator(aetest.Testcase):
                                 for nei_id, nei_data in vrf_data.get('neighbors', {}).items():
                                     if nei_id == peer_id:
                                         peer_found = True
-                                        """
-                                        Get state & normalise - some variations in output format between OS
-                                        """
-                                        state = nei_data.get('nbr_state', '').lower()
+                                        state = normalize_bgp_state(nei_data.get('nbr_state', ''))
                                         if state:
                                             actual_state = state
                                         else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 telnetlib-313-and-up
 pyats[full]
 pyyaml
+pytest

--- a/tests/test_state_normalization.py
+++ b/tests/test_state_normalization.py
@@ -1,0 +1,55 @@
+import os
+import sys
+import types
+import pytest
+
+# Add repository root to path so modules can be imported when running tests
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+# Stub out optional dependencies used in modules so imports succeed during unit tests
+pyats_mod = types.ModuleType('pyats')
+aetest_mod = types.ModuleType('pyats.aetest')
+setattr(aetest_mod, 'CommonSetup', type('CommonSetup', (), {}))
+setattr(aetest_mod, 'Testcase', type('Testcase', (), {}))
+setattr(aetest_mod, 'CommonCleanup', type('CommonCleanup', (), {}))
+setattr(aetest_mod, 'subsection', lambda *args, **kwargs: (lambda func: func))
+setattr(aetest_mod, 'test', lambda *args, **kwargs: (lambda func: func))
+pyats_mod.aetest = aetest_mod
+sys.modules.setdefault('pyats', pyats_mod)
+sys.modules.setdefault('pyats.aetest', aetest_mod)
+genie_mod = types.ModuleType('genie')
+testbed_mod = types.ModuleType('genie.testbed')
+setattr(testbed_mod, 'load', lambda *args, **kwargs: None)
+genie_mod.testbed = testbed_mod
+sys.modules.setdefault('genie', genie_mod)
+sys.modules.setdefault('genie.testbed', testbed_mod)
+
+from ospf_nei_check.ospf_nei_check import normalize_ospf_state
+from bgp_peer_check.bgp_peer_check import normalize_bgp_state
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("full/dr", "full/dr"),
+        ("full/bdr", "full/bdr"),
+        ("full/  -", "full"),
+        ("full/", "full"),
+        (" full ", "full"),
+        (" full/BDr ", "full/bdr"),
+    ],
+)
+def test_normalize_ospf_state(raw, expected):
+    assert normalize_ospf_state(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("Established", "established"),
+        (" established ", "established"),
+        ("Idle", "idle"),
+    ],
+)
+def test_normalize_bgp_state(raw, expected):
+    assert normalize_bgp_state(raw) == expected


### PR DESCRIPTION
## Summary
- provide helper functions for OSPF/BGP state normalisation
- cover normalisation logic with pytest unit tests
- document how to run the tests
- add pytest dependency

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68402cb7f32c832899cfba5e1b1a36fe